### PR TITLE
enable coveralls for non-ci karma run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # js-animate
 [![Build Status](https://travis-ci.org/gaggle/js-animate.svg?branch=master)](https://travis-ci.org/gaggle/js-animate)
+[![Coverage Status](https://coveralls.io/repos/github/gaggle/js-animate/badge.svg?branch=master)](https://coveralls.io/github/gaggle/js-animate?branch=master)
 
 Very simple js-based animation. Based on http://jsfiddle.net/LzX4s/, I just switched to Promises and added tests.
 

--- a/karma.ci.conf.js
+++ b/karma.ci.conf.js
@@ -38,26 +38,17 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      "./test/*.js",
-      "./lib/*.js"
+      "./test/*.js"
     ],
 
     preprocessors: {
-      "./test/*.js": ["browserify"],
-      "./lib/*.js": ["browserify"]
+      "./test/*.js": ["browserify"]
     },
 
     reporters: ["dots", "saucelabs"],
 
     browserify: {
-      debug: true, // generate source maps for easier debugging
-      transform: ["browserify-istanbul"]
-    },
-
-    coverageReporter: {
-      reporters: [
-        {type: "lcov", dir: ".coverage"}
-      ]
+      debug: true // generate source maps for easier debugging
     },
 
     urlRoot: "/__karma__/",
@@ -76,7 +67,7 @@ module.exports = function (config) {
     browserNoActivityTimeout: 90000,
 
     sauceLabs: {
-      testName: "js-animate tests",
+      testName: "js-animate",
       tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
       startConnect: false
     }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,7 @@ module.exports = function (config) {
       "./test/*.js": ["browserify"]
     },
 
-    reporters: ["dots", "coverage"],
+    reporters: ["dots", "coverage", "coveralls"],
 
     browserify: {
       debug: true, // generate source maps for easier debugging

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "karma-browserify": "^5.0.4",
     "karma-chai": "^0.1.0",
     "karma-coverage": "^0.5.5",
+    "karma-coveralls": "^1.1.2",
     "karma-mocha": "^0.2.2",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sauce-launcher": "^0.3.1",


### PR DESCRIPTION
(which also gets invoked on travis)
